### PR TITLE
Repair PostgreSQL configuration tasks

### DIFF
--- a/roles/postgres/files/docker-entrypoint-initdb.d/init.sh
+++ b/roles/postgres/files/docker-entrypoint-initdb.d/init.sh
@@ -1,1 +1,2 @@
-echo -e "host all all peer\nhost all all 127.0.0.1/32 md5" > "$PGDATA/pg_hba.conf"
+#!/bin/bash
+echo -e "host all all all md5\n" > "$PGDATA/pg_hba.conf"

--- a/roles/postgres/handlers/main.yml
+++ b/roles/postgres/handlers/main.yml
@@ -1,6 +1,0 @@
-- name: Restart PostgreSQL
-  tags:
-    - never
-  docker_container:
-    name: postgres
-    restart: yes

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -13,16 +13,25 @@
   docker_volume:
     name: postgres
 
+- name: Remove PostgreSQL volume
+  tags:
+    - never
+    - clean-postgres
+  docker_volume:
+    name: postgres
+    state: absent
+
 - name: Configure PostgreSQL
   tags:
     - configure-system
     - configure-postgres
   synchronize:
-    src: '{{ inventory_dir }}/roles/postgres/files'
-    dest: ~/
-    existing_only: false
+    src: '{{ inventory_dir }}/roles/postgres/files/'
+    dest: ~/postgres
+    existing_only: no
+    recursive: yes
+    perms: yes
     private_key: ~/.ssh/id_rsa
-  notify: Restart PostgreSQL
 
 - name: Start PostgreSQL container
   tags:
@@ -31,9 +40,11 @@
   docker_container:
     name: postgres
     image: postgres:11
+    env:
+      POSTGRES_PASSWORD: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
     volumes:
+      - /home/ubuntu/postgres/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d/
       - postgres:/var/lib/postgresql/data/
-      - /home/ubuntu/postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d/
     ports:
       - 5432:5432
 


### PR DESCRIPTION
Repair bugs in PostgreSQL configuration tasks. Note that [removing the data volume](https://github.com/docker-library/postgres/issues/203#issuecomment-255200501) seems to be the only way to force the `docker-entrypoint-initdb.d` scripts to run. 